### PR TITLE
CI Uploads PDFs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,14 @@
 language: generic
-
 before_install:
-  - sudo apt-get update
-  - sudo apt-get install texlive-xetex latexmk lmodern texlive-fonts-recommended
-
+- sudo apt-get update
+- sudo apt-get install texlive-xetex latexmk lmodern texlive-fonts-recommended
 script:
-  - make all 
-
+- make all
 notifications:
   slack:
     secure: bits-n-bots:1dqjI7NFiADCbSQTw4nhAGI6
-
 after_success:
-  - ./push-lessons.sh
+- "./push-lessons.sh"
+env:
+  global:
+    secure: qA4++0OTPy26pQrAOsOESJ4vtbHlZ+zYUCNwiXb3l+MYZkIAE5QLkuJUDom0OQ1c9mYuLIWFHinHhBw3vVmpFioBsNJ9lgWpbhCZQUKH4t3RlsRnvlylrl1jW8HPAQmKe+1WIE/MhD03y1f+vdDIv/B6SexVnPf+9fHpaDgZo1NgZ0C5/Uv7AjfmuZIjzhHHqGM6lLfJR4LqzKB1CHPGzzxsdOE/SXrtZnD73StYk8sxXF0PuWaCiDBIt5KgXuGGchCGcDkkf2kWMHt8j1sL1HEPyuQb4z+1d2P9BpgEjGTBR7xv++imuab8QdRbRHSm/xUOMH9zb3h2qQHuZwMpTVGFGbflj1nhMpyC5YKM5aqMdPrQIRWyxdJLapE3c+xivinWSw5pNjLJe7FpJ+7oF3Ng5Qe8jkcwjxDHVasRuGN+UFT247dLsCSbU0x4BN++ANZfaRE9kgU340AmFexk1vuHMSx8J9M78LjWG+alywlYNkejHz3ZqNJnqTZXw/8RDA+8PDega6GfgyAu+qJdUnrRAe4Wr8USUvACYo3y5MYNL7AgBi5uV5ntajp4shWFsLWZSRswvz0oO3TKGUmJMjTkDV1aY1GmEzIopcNDa3vwpPu04Q8DrUKzL6uoCGD0z9X/GsKKjmeEw/6JEzZd22sEpfjeAVqk17Wo1S1MAQk=

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,3 +11,5 @@ notifications:
   slack:
     secure: bits-n-bots:1dqjI7NFiADCbSQTw4nhAGI6
 
+after_success:
+  - ./push-lessons.sh

--- a/push-lessons.sh
+++ b/push-lessons.sh
@@ -14,7 +14,7 @@ commit_lessons() {
   rm -rf out
 
   # Add and commit all lessons
-  git add *.pdf
+  git add -A
   git commit --message "Travis build: $TRAVIS_BUILD_NUMBER"
   git checkout -b lesson-pdfs
 }
@@ -25,7 +25,7 @@ upload_lessons() {
   # on the travis server with a bot accounts PAT.
   git remote add lesson-pdfs https://${GH_TOKEN}@github.com/bits-and-bots/lessons.git > /dev/null 2>&1
   # Make sure nothing is exposed in logs
-  git push --quiet --set-upstream lesson-pdfs >/dev/null 2>&1
+  git push --quiet --set-upstream lesson-pdfs > /dev/null 2>&1
 }
 
 if [[ $TRAVIS_BRANCH == 'master' ]]

--- a/push-lessons.sh
+++ b/push-lessons.sh
@@ -3,21 +3,29 @@
 # Thanks to willprice: https://gist.github.com/willprice/e07efd73fb7f13f917ea
 
 setup_git() {
-  git config --global user.email "travis@travis-ci.org"
-  git config --global user.name "Travis CI"
+  git config --global user.email "bot@bits-and-bots.github.io"
+  git config --global user.name "Bits&Bots Bot"
 }
 
 commit_lessons() {
-  git checkout -b lesson-pdfs
-  git add out/*
+  # remove everything except for lessons
+  rm ./*
+  cp out/* .
+  rm -rf out
+
+  # Add and commit all lessons
+  git add *.pdf
   git commit --message "Travis build: $TRAVIS_BUILD_NUMBER"
+  git checkout -b lesson-pdfs
 }
 
 upload_lessons() {
   # We can set this to a different location later if preferred, or just
-  # upload to an S3 bucket etc.
-  git remote add lesson-pdfs git@github.com:bits-and-bots/lessons.git
-  git push --set-upstream lesson-pdfs
+  # upload to an S3 bucket etc. Notice this relies currently on an env var
+  # on the travis server with a bot accounts PAT.
+  git remote add lesson-pdfs https://${GH_TOKEN}@github.com/bits-and-bots/lessons.git > /dev/null 2>&1
+  # Make sure nothing is exposed in logs
+  git push --quiet --set-upstream lesson-pdfs >/dev/null 2>&1
 }
 
 if [[ $TRAVIS_BRANCH == 'master' ]]

--- a/push-lessons.sh
+++ b/push-lessons.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# Thanks to willprice: https://gist.github.com/willprice/e07efd73fb7f13f917ea
+
+setup_git() {
+  git config --global user.email "travis@travis-ci.org"
+  git config --global user.name "Travis CI"
+}
+
+commit_lessons() {
+  git checkout -b lesson-pdfs
+  git add out/*
+  git commit --message "Travis build: $TRAVIS_BUILD_NUMBER"
+}
+
+upload_lessons() {
+  # We can set this to a different location later if preferred, or just
+  # upload to an S3 bucket etc.
+  git remote add lesson-pdfs git@github.com:bits-and-bots/lessons.git
+  git push --set-upstream lesson-pdfs
+}
+
+if [[ $TRAVIS_BRANCH == 'master' ]]
+    setup_git
+    commit_lessons
+    upload_lessons
+fi


### PR DESCRIPTION
hmmm, i wonder if this will work...?

Don't have time right now to set up a local environment to test this in, so let's just give it a run and see.

For now, they're uploaded to a new branch, but the uploading location can easily be changed by modifying one function.

The PAT `GH_TOKEN` was generated using a bot account that only has access to the B&B repos. It's encrypted as a secure variable, and I rerouted the text output of all commands I think could potentially expose it in the logs